### PR TITLE
Replace getopt by argparse

### DIFF
--- a/keyer.py
+++ b/keyer.py
@@ -3,7 +3,6 @@ import sys
 import serial
 import argparse
 
-ser = ditspeed = dahspeed = charspace = wordspace = ""
 chars =   {'A':'.-',
            'B':'-...',
            'C':'-.-.',
@@ -98,32 +97,23 @@ def paris():
     count+=1
     print(count)
 
-def main(argv):
-   # set defaults
-   text = ''
-   wpm = 20
-   global ser,ditspeed,dahspeed,charspace,wordspace,pin
-   parser = argparse.ArgumentParser(description='CW keyer for serial interface.')
-   parser.add_argument('-d', '--device', dest='device', default='/dev/ttyUSB0', help='Path to serial device. (default: /dev/ttyUSB0)')
-   parser.add_argument('-w', '--wpm', dest='wpm', type=int, default=20, help='CW keying speed in words per minutes. (default: 20 wpm)')
-   parser.add_argument('-t', '--text', dest='text', required=True, help='Text to transmit. Surround multiple words by quotes.')
-   parser.add_argument('--dtr', dest='dtr', action='store_true', help='Use DTR pin instead of RTS pin for keying')
-   args = parser.parse_args()
+parser = argparse.ArgumentParser(description='CW keyer for serial interface.')
+parser.add_argument('-d', '--device', dest='device', default='/dev/ttyUSB0', help='Path to serial device. (default: /dev/ttyUSB0)')
+parser.add_argument('-w', '--wpm', dest='wpm', type=int, default=20, help='CW keying speed in words per minutes. (default: 20 wpm)')
+parser.add_argument('-t', '--text', dest='text', required=True, help='Text to transmit. Surround multiple words by quotes.')
+parser.add_argument('--dtr', dest='dtr', action='store_true', help='Use DTR pin instead of RTS pin for keying')
+args = parser.parse_args()
 
-   if args.dtr:
-       pin='DTR'
-   else:
-       pin='RTS'
+if args.dtr:
+   pin='DTR'
+else:
+   pin='RTS'
 
-   ser = serial.Serial(args.device, 9600);
-   ditspeed = (1200.0 / float(args.wpm)) / 1000.0
-   dahspeed = ditspeed * 3
-   charspace = ditspeed * 1
-   wordspace = ditspeed * 7
+ser = serial.Serial(args.device, 9600);
+ditspeed = (1200.0 / float(args.wpm)) / 1000.0
+dahspeed = ditspeed * 3
+charspace = ditspeed * 1
+wordspace = ditspeed * 7
 
-   for w in args.text.upper().split():
-       word(w)
-
-if __name__ == "__main__":
-   main(sys.argv[1:])
-
+for w in args.text.upper().split():
+   word(w)

--- a/keyer.py
+++ b/keyer.py
@@ -1,7 +1,8 @@
 import time
 import sys
 import serial
-import getopt
+import argparse
+
 ser = ditspeed = dahspeed = charspace = wordspace = ""
 chars =   {'A':'.-',
            'B':'-...',
@@ -103,39 +104,25 @@ def main(argv):
    wpm = 20
    device = '/dev/ttyUSB0'
    global ser,ditspeed,dahspeed,charspace,wordspace,pin
-   pin="RTS"
-   try:
-      opts, args = getopt.getopt(argv,"d:w:t:p",["d=","w=","t=","p="])
-   except getopt.GetoptError:
-         print('test.py -d <device> -w <wpm> -t <text> -p <pin - R for RTS, D for DTR>')
-         sys.exit(2)
-   for opt, arg in opts:
-      if opt in ("-d", "--device"):
-         device = arg
-      elif opt in ("-w", "--wpm"):
-         wpm = arg
-      elif opt in ("-t", "--text"):
-         text = arg.upper()
-      elif opt in ("-p", "--pin"):
-         pinarg = arg.upper()
-         print(opt)
-         print(arg)
-         if pinarg == "R":
-           print("set pin RTS")
-           pin="RTS"
-         elif pinarg == "D":
-           print("set pin DTR")
-           pin="DTR"
-      
-         
-   
-   ser = serial.Serial(device, 9600);
-   ditspeed = (1200.0 / float(wpm)) / 1000.0
+   parser = argparse.ArgumentParser(description='CW keyer for serial interface.')
+   parser.add_argument('-d', '--device', dest='device', required=True, help='Path to serial device. (e.g. /dev/ttyUSB0)')
+   parser.add_argument('-w', '--wpm', dest='wpm', type=int, default=20, help='CW keying speed in words per minutes. (default: 20 wpm)')
+   parser.add_argument('-t', '--text', dest='text', required=True, help='Text to transmit. Surround multiple words by quotes.')
+   parser.add_argument('--dtr', dest='dtr', action='store_true', help='Use DTR pin instead of RTS pin for keying')
+   args = parser.parse_args()
+
+   if args.dtr:
+       pin='DTR'
+   else:
+       pin='RTS'
+
+   ser = serial.Serial(args.device, 9600);
+   ditspeed = (1200.0 / float(args.wpm)) / 1000.0
    dahspeed = ditspeed * 3
    charspace = ditspeed * 1
    wordspace = ditspeed * 7
 
-   for w in text.split():
+   for w in args.text.upper().split():
        word(w)
 
 if __name__ == "__main__":

--- a/keyer.py
+++ b/keyer.py
@@ -102,10 +102,9 @@ def main(argv):
    # set defaults
    text = ''
    wpm = 20
-   device = '/dev/ttyUSB0'
    global ser,ditspeed,dahspeed,charspace,wordspace,pin
    parser = argparse.ArgumentParser(description='CW keyer for serial interface.')
-   parser.add_argument('-d', '--device', dest='device', required=True, help='Path to serial device. (e.g. /dev/ttyUSB0)')
+   parser.add_argument('-d', '--device', dest='device', default='/dev/ttyUSB0', help='Path to serial device. (default: /dev/ttyUSB0)')
    parser.add_argument('-w', '--wpm', dest='wpm', type=int, default=20, help='CW keying speed in words per minutes. (default: 20 wpm)')
    parser.add_argument('-t', '--text', dest='text', required=True, help='Text to transmit. Surround multiple words by quotes.')
    parser.add_argument('--dtr', dest='dtr', action='store_true', help='Use DTR pin instead of RTS pin for keying')


### PR DESCRIPTION
Python's argparse allows more versatile and easier processing of command line argument. This feature branch introduces the following changes:

- Use argparse instead of getopt
- Provide a help text on --help or if mandatory parameters are missing
- Force the -w parameter to be an integer
- Pin handling defaults to RTS, --dtr switches to DTR
- Got rid of global and main()