### PR TITLE
Skip unknown characters and print error message

### DIFF
--- a/keyer.py
+++ b/keyer.py
@@ -81,7 +81,13 @@ def dit():
 
 def word(w):
   for c in w:
-      code = chars[c]
+      try:
+          code = chars[c]
+      except KeyError:
+          # FIXME: Use proper logging facility here
+          print('Skipping unknown character %s' % c)
+          continue
+
       for dahdit in code:
         if dahdit == '-':
           dah()


### PR DESCRIPTION
So far, the program was crashing on characters that were absent from the CW mapping table. This bugfix addresses this issue by skipping those characters and printing an error instead.